### PR TITLE
Add Specifier macro

### DIFF
--- a/src/address.rs
+++ b/src/address.rs
@@ -2,7 +2,7 @@ use core::fmt;
 
 use crate::blake2b::{Accumulator, LEAF_HASH_PREFIX};
 use crate::encoding::to_writer;
-use crate::{specifier::Specifier, HexParseError, PublicKey, UnlockKey};
+use crate::{Algorithm, HexParseError, PublicKey, UnlockKey};
 use blake2b_simd::Params;
 use serde::Serialize;
 
@@ -83,35 +83,6 @@ impl fmt::Display for Address {
 
         buf[32..].copy_from_slice(&h.as_bytes()[..6]);
         write!(f, "addr:{}", hex::encode(buf))
-    }
-}
-
-#[derive(Debug, PartialEq, Clone, Copy)]
-pub enum Algorithm {
-    ED25519,
-}
-
-impl fmt::Display for Algorithm {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Algorithm::ED25519 => write!(f, "ed25519"),
-        }
-    }
-}
-
-impl Serialize for Algorithm {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let str = match self {
-            Algorithm::ED25519 => "ed25519",
-        };
-        if serializer.is_human_readable() {
-            serializer.serialize_str(str)
-        } else {
-            Specifier::from(str).serialize(serializer)
-        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,10 +6,10 @@ pub mod currency;
 pub mod encoding;
 pub mod seed;
 pub mod signing;
-pub mod specifier;
 pub mod spendpolicy;
 pub mod transactions;
 
+pub(crate) mod specifier;
 pub(crate) mod blake2b;
 
 pub use address::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,8 @@ pub mod signing;
 pub mod spendpolicy;
 pub mod transactions;
 
-pub(crate) mod specifier;
 pub(crate) mod blake2b;
+pub(crate) mod specifier;
 
 pub use address::*;
 pub use consensus::*;

--- a/src/signing.rs
+++ b/src/signing.rs
@@ -3,7 +3,7 @@ use std::time::SystemTime;
 
 use crate::consensus::ChainIndex;
 use crate::encoding::{to_writer, SerializeError};
-use crate::specifier::{specifier,Specifier};
+use crate::specifier::{specifier, Specifier};
 use crate::transactions::{CoveredFields, Transaction};
 use crate::{Hash256, HexParseError};
 use blake2b_simd::Params;

--- a/src/specifier.rs
+++ b/src/specifier.rs
@@ -1,13 +1,36 @@
+use core::{fmt, str};
+
 use serde::Serialize;
 
-const SPECIFIER_SIZE: usize = 16;
+pub const SPECIFIER_SIZE: usize = 16;
 
 #[derive(Debug, PartialEq, Serialize)]
 pub struct Specifier([u8; SPECIFIER_SIZE]);
 
-// implement the `From` trait for the `Specifier` struct to allow for creating a
-// Specifier from any type that can be converted to a slice of bytes such as
-// 'String', '&str' or byte arrays.
+impl Specifier {
+    pub const fn new(buf: [u8; SPECIFIER_SIZE]) -> Self {
+        Self(buf)
+    }
+
+    pub fn as_bytes(&self) -> &[u8; SPECIFIER_SIZE] {
+        &self.0
+    }
+}
+
+impl fmt::Display for Specifier {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // get the last non-zero byte or 0 if all bytes are 0
+        let index = self
+            .0
+            .iter()
+            .rev()
+            .position(|&x| x != 0)
+            .map_or(0, |pos| SPECIFIER_SIZE - pos);
+        let str = str::from_utf8(&self.0[..index]).map_err(|_| fmt::Error)?;
+        write!(f, "{}", str)
+    }
+}
+
 impl<T: AsRef<[u8]>> From<T> for Specifier {
     fn from(src: T) -> Self {
         let src = src.as_ref();
@@ -17,6 +40,26 @@ impl<T: AsRef<[u8]>> From<T> for Specifier {
         spec
     }
 }
+
+macro_rules! specifier {
+    ($text:expr) => {{
+        let src = $text.as_bytes();
+        let len = src.len();
+        assert!(
+            len <= $crate::specifier::SPECIFIER_SIZE,
+            "specifier too long"
+        );
+        let mut buf = [0; 16];
+        let mut index: usize = 0;
+        while index < len {
+            buf[index] = src[index];
+            index += 1;
+        }
+        $crate::specifier::Specifier::new(buf)
+    }};
+}
+
+pub(crate) use specifier;
 
 #[cfg(test)]
 mod tests {
@@ -29,5 +72,31 @@ mod tests {
             b'h', b'e', b'l', b'l', b'o', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         ]);
         assert_eq!(spec, expected);
+    }
+
+    #[test]
+    fn test_specifier_macro() {
+        let test_cases = vec![(specifier!["hello world"], "hello world")];
+        for (specifier, expected) in test_cases {
+            assert_eq!(specifier.to_string(), expected);
+        }
+    }
+
+    #[test]
+    fn test_specifier_string() {
+        let test_cases = vec![
+            (specifier!["hello world"], "hello world"),
+            (specifier!["hello"], "hello"),
+            (
+                Specifier::from([
+                    b'h', b'e', b'l', b'l', b'o', 0, b'w', b'o', b'r', b'l', b'd',
+                ]),
+                "hello\0world",
+            ),
+            (Specifier::new([0; 16]), ""),
+        ];
+        for (specifier, expected) in test_cases {
+            assert_eq!(specifier.to_string(), expected);
+        }
     }
 }

--- a/src/specifier.rs
+++ b/src/specifier.rs
@@ -31,6 +31,9 @@ impl fmt::Display for Specifier {
     }
 }
 
+// implement the `From` trait for the `Specifier` struct to allow for creating a
+// Specifier from any type that can be converted to a slice of bytes such as
+// 'String', '&str' or byte arrays.
 impl<T: AsRef<[u8]>> From<T> for Specifier {
     fn from(src: T) -> Self {
         let src = src.as_ref();

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -1,19 +1,11 @@
-use core::fmt;
-
 use crate::encoding::{serialize_array, to_writer};
+use crate::specifier::{specifier, Specifier};
 use crate::Currency;
 use crate::Signature;
-use crate::{Address, UnlockConditions};
-use crate::{Hash256, HexParseError};
+use crate::{Address, Hash256, HexParseError, UnlockConditions};
 use blake2b_simd::{Params, State};
+use core::fmt;
 use serde::Serialize;
-
-const SIACOIN_OUTPUT_ID_PREFIX: [u8; 16] = [
-    b's', b'i', b'a', b'c', b'o', b'i', b'n', b' ', b'o', b'u', b't', b'p', b'u', b't', 0, 0,
-];
-const SIAFUND_OUTPUT_ID_PREFIX: [u8; 16] = [
-    b's', b'i', b'a', b'f', b'u', b'n', b'd', b' ', b'o', b'u', b't', b'p', b'u', b't', 0, 0,
-];
 
 #[derive(Debug, Clone, Serialize)]
 pub struct SiacoinOutputID([u8; 32]);
@@ -253,6 +245,9 @@ pub struct Transaction {
 }
 
 impl Transaction {
+    const SIACOIN_OUTPUT_ID_PREFIX: Specifier = specifier!("siacoin output");
+    const SIAFUND_OUTPUT_ID_PREFIX: Specifier = specifier!("siafund output");
+
     pub fn encode_no_sigs(&self) -> Vec<u8> {
         let mut buf = Vec::new();
 
@@ -364,7 +359,7 @@ impl Transaction {
     pub fn siacoin_output_id(&self, i: usize) -> SiacoinOutputID {
         let mut state = Params::new().hash_length(32).to_state();
 
-        state.update(&SIACOIN_OUTPUT_ID_PREFIX);
+        state.update(Self::SIACOIN_OUTPUT_ID_PREFIX.as_bytes());
         self.hash_no_sigs(&mut state);
 
         SiacoinOutputID(
@@ -380,7 +375,7 @@ impl Transaction {
     pub fn siafund_output_id(&self, i: usize) -> SiafundOutputID {
         let mut state = Params::new().hash_length(32).to_state();
 
-        state.update(&SIAFUND_OUTPUT_ID_PREFIX);
+        state.update(Self::SIAFUND_OUTPUT_ID_PREFIX.as_bytes());
         self.hash_no_sigs(&mut state);
 
         SiafundOutputID(


### PR DESCRIPTION
Changes all uses of Specifier to `consts` and moves `Algorithm` out of the address module and into the signing module with `UnlockKey` and other signing-related things. 

Let's take another look at the package structure in a f/u. I think there are some areas we could improve on, especially once we start looking at adding the other v2 types.