### PR TITLE
Avoid allocation in sector roots

### DIFF
--- a/src/rhp.rs
+++ b/src/rhp.rs
@@ -18,14 +18,14 @@ pub fn sector_root(sector: &[u8]) -> Hash256 {
         .collect::<Vec<_>>();
 
     let mut step_size = 1;
+    let mut chunk_size = 2;
     while step_size < tree_hashes.len() {
         tree_hashes
-            .par_iter_mut()
-            .step_by(step_size)
-            .chunks(2)
-            .for_each(|mut nodes| {
-                *nodes[0] = sum_node(&params, nodes[0], nodes[1]);
+            .par_chunks_exact_mut(chunk_size)
+            .for_each(|nodes| {
+                nodes[0] = sum_node(&params, &nodes[0], &nodes[step_size]);
             });
+        chunk_size *= 2;
         step_size *= 2;
     }
     Hash256::from(tree_hashes[0])

--- a/src/rhp.rs
+++ b/src/rhp.rs
@@ -17,16 +17,14 @@ pub fn sector_root(sector: &[u8]) -> Hash256 {
         .map(|chunk| sum_leaf(&params, chunk))
         .collect::<Vec<_>>();
 
-    let mut step_size = 1;
     let mut chunk_size = 2;
-    while step_size < tree_hashes.len() {
+    while chunk_size <= tree_hashes.len() {
         tree_hashes
             .par_chunks_exact_mut(chunk_size)
             .for_each(|nodes| {
-                nodes[0] = sum_node(&params, &nodes[0], &nodes[step_size]);
+                nodes[0] = sum_node(&params, &nodes[0], &nodes[nodes.len() / 2]);
             });
         chunk_size *= 2;
-        step_size *= 2;
     }
     Hash256::from(tree_hashes[0])
 }


### PR DESCRIPTION
I noticed that the inline type hints showed a `Vec` as an intermediary result. Apparently `chunks` requires a vector to pass on the references of `step_by`. 
This PR fixes that to avoid that allocation and uses the recommended `par_chunks_exact_mut` instead of `chunks`.

```
     Running benches/merkle_root.rs (target/release/deps/merkle_root-9e0ec57c6e502a76)
Gnuplot not found, using plotters backend
sector_root             time:   [2.9715 ms 2.9886 ms 3.0070 ms]
                        change: [-8.0434% -6.9685% -6.0062%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
```